### PR TITLE
Running rustfmt to format according to standard rust formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 pub mod commit;
+mod curve;
 pub mod elgamal;
+mod scalar;
 pub mod shuffle;
 pub mod threshold;
 pub mod util;
 pub mod zkp;
-mod scalar;
-mod curve;
 
 use std::convert::TryInto;
 use std::error::Error;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,10 +1,10 @@
-use crate::{base64_serde, CryptoError, AsBase64};
+use crate::curve::CurveElem;
+use crate::{base64_serde, AsBase64, CryptoError};
 use curve25519_dalek::scalar::Scalar as InternalDalekScalar;
 use num_bigint::BigUint;
-use std::ops::{Add, Mul, Neg};
-use std::iter::{Sum, Product};
 use std::convert::{TryFrom, TryInto};
-use crate::curve::CurveElem;
+use std::iter::{Product, Sum};
+use std::ops::{Add, Mul, Neg};
 
 pub(crate) type DalekScalar = InternalDalekScalar;
 
@@ -83,13 +83,13 @@ impl Neg for Scalar {
 }
 
 impl Sum<Scalar> for Scalar {
-    fn sum<I: Iterator<Item=Scalar>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = Scalar>>(iter: I) -> Self {
         iter.fold(Scalar(DalekScalar::zero()), |a, b| a + b)
     }
 }
 
 impl Product<Scalar> for Scalar {
-    fn product<I: Iterator<Item=Scalar>>(iter: I) -> Self {
+    fn product<I: Iterator<Item = Scalar>>(iter: I) -> Self {
         iter.fold(Scalar(DalekScalar::one()), |a, b| a * b)
     }
 }
@@ -183,8 +183,8 @@ impl Into<BigUint> for Scalar {
 
 #[cfg(test)]
 mod tests {
-    use num_bigint::BigUint;
     use crate::elgamal::CryptoContext;
+    use num_bigint::BigUint;
 
     #[test]
     fn test_biguint_scalar() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,7 @@
-pub trait AsBase64 where Self: Sized {
+pub trait AsBase64
+where
+    Self: Sized,
+{
     type Error;
 
     fn as_base64(&self) -> String;
@@ -12,9 +15,9 @@ pub const SCALAR_MAX_BYTES: usize = ((252 - K) / 8) as usize;
 macro_rules! base64_serde {
     ($name:ty) => {
         mod base64_serde_inner {
+            use super::AsBase64;
             use serde::de;
             use std::fmt;
-            use super::AsBase64;
 
             pub struct Base64Visitor;
 
@@ -26,27 +29,35 @@ macro_rules! base64_serde {
                 }
 
                 fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-                    where
-                        E: de::Error {
+                where
+                    E: de::Error,
+                {
                     <$name>::try_from_base64(value)
                         .map_err(|_| de::Error::custom("not a valid encoding"))
                 }
             }
         }
         impl serde::Serialize for $name {
-            fn serialize<S>(&self, serializer: S) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
-                where
-                    S: serde::Serializer {
+            fn serialize<S>(
+                &self,
+                serializer: S,
+            ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+            where
+                S: serde::Serializer,
+            {
                 serializer.serialize_str(&self.as_base64())
             }
         }
 
         impl<'de> serde::Deserialize<'de> for $name {
-            fn deserialize<D>(deserializer: D) -> Result<Self, <D as serde::Deserializer<'de>>::Error>
-                where
-                    D: serde::Deserializer<'de> {
+            fn deserialize<D>(
+                deserializer: D,
+            ) -> Result<Self, <D as serde::Deserializer<'de>>::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
                 deserializer.deserialize_str(base64_serde_inner::Base64Visitor)
             }
         }
-    }
+    };
 }


### PR DESCRIPTION
Hi there, 

Thank you for this awesome project!  

I'm going to be opening up a series of pull-requests with improvements to documentation, usability, dependencies and modularity.  To start, I've run `rustfmt src/*` to format the source-code according to rust standard formatting rules.   This will allow follow-up pull-requests to have reasonable diffs. 

If you don't want to merge this (it's a big change) and instead do it yourself, you can just run `rustfmt src/*` to get the same result.

Thank you!