### PR TITLE
Specifying dependency versions for pre 1.0 dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,14 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-num-bigint = { version = "0", features = ["rand", "serde"] }
-ring = "0"
-curve25519-dalek = { package="curve25519-dalek-ng", version = "4", features = ["serde", "std"] }
-num-traits = "0"
-base64 = "0"
-rand_chacha = "0"
-rand = "0"
+num-bigint = { version = "0.4", features = ["rand", "serde"] }
+ring = "0.16"
+curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", features = [
+    "serde",
+    "std"
+] }
+num-traits = "0.2"
+base64 = "0.13"
+rand_chacha = "0.3"
+rand = "0.8"
 rayon = "1.3"


### PR DESCRIPTION
This pull request specifies the specific version required for pre 1.0 dependencies. 

According to cargo semver, point releases for pre 1.0 crates are considered breaking changes.  This means that specifying "0" as the version for a pre 1.0 dependency could result in Cargo selecting an incompatible version for the dependency.   

This is actually what happened to me when I tried to use cryptid, `rand_chacha` was selected at version `0.1`, even though cryptid requires `rand_chacha` to be `0.3` compatible.   You won't run into this when running cryptid standalone since cargo will select the latest versions, but you could run into the problem when using cryptid as a dependency. 

This pull request lifts all the versions specified in `Cargo.lock` and lifts them into `Cargo.toml` to fix this issue. 
